### PR TITLE
Bug 1397801 - In VisitCallExpr, wait until we get the real location o…

### DIFF
--- a/clang-plugin/Indexer.cpp
+++ b/clang-plugin/Indexer.cpp
@@ -1188,12 +1188,7 @@ public:
 
     const NamedDecl *namedCallee = dyn_cast<NamedDecl>(callee);
 
-    SourceLocation startLoc = callee->getLocStart();
-    SourceLocation loc = startLoc;
-    NormalizeLocation(&loc);
-    if (!IsInterestingLocation(loc)) {
-      return true;
-    }
+    SourceLocation loc;
 
     const FunctionDecl *f = dyn_cast<FunctionDecl>(namedCallee);
     if (f->isTemplateInstantiation()) {
@@ -1208,20 +1203,25 @@ public:
       // Just take the first token.
       CXXOperatorCallExpr* op = dyn_cast<CXXOperatorCallExpr>(e);
       loc = op->getOperatorLoc();
-      NormalizeLocation(&loc);
     } else if (MemberExpr::classof(calleeExpr)) {
       MemberExpr* member = dyn_cast<MemberExpr>(calleeExpr);
       loc = member->getMemberLoc();
-      NormalizeLocation(&loc);
     } else if (DeclRefExpr::classof(calleeExpr)) {
       // We handle this in VisitDeclRefExpr.
       return true;
     } else {
-      if (callee->getLocEnd() != startLoc) {
+      if (callee->getLocEnd() != callee->getLocStart()) {
         // Skip this call. If we can't find a single token, we don't have a
         // good UI for displaying the call.
         return true;
       }
+      loc = callee->getLocStart();
+    }
+
+    NormalizeLocation(&loc);
+
+    if (!IsInterestingLocation(loc)) {
+      return true;
     }
 
     VisitToken("use", "function", GetQualifiedName(namedCallee), loc, mangled, GetContext(loc));


### PR DESCRIPTION
…f the callee to decide if it is interesting.

The start of a declaration of a thing being called can end up being
the return type, such as bool. When it is a primitive type like bool,
then the normalized location ends up being uninteresting, so nothing
ends up being reported for the call.

(billm, mrbkap and I worked together to figure this out.)