### PR TITLE
Bug 1416876 - Make crossref output stable.

### DIFF
--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -75,9 +75,9 @@ fn main() {
     let jump_file = format!("{}/jumps", tree_config.paths.index_path);
     let id_file = format!("{}/identifiers", tree_config.paths.index_path);
 
-    let mut table = HashMap::new();
+    let mut table = BTreeMap::new();
     let mut pretty_table = HashMap::new();
-    let mut id_table = HashMap::new();
+    let mut id_table = BTreeMap::new();
     let mut jumps = Vec::new();
 
     {


### PR DESCRIPTION
One file is generated by iterating over a HashMap keyed by heap
allocated structures (table) so the output is not consistent. Using a
BtreeMap fixes this.

id_table technically has this problem, too, though in practice because
it is keyed with strings the order seems to be consistent.

The third output is generated from a vector, so it should be okay.