### PR TITLE
Reduce memory usage in crossref.rs by sharing strings

### DIFF
--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -75,9 +75,9 @@ fn main() {
     let jump_file = format!("{}/jumps", tree_config.paths.index_path);
     let id_file = format!("{}/identifiers", tree_config.paths.index_path);
 
-    let mut table = HashMap::new();
+    let mut table = BTreeMap::new();
     let mut pretty_table = HashMap::new();
-    let mut id_table = HashMap::new();
+    let mut id_table = BTreeMap::new();
     let mut jumps = Vec::new();
 
     {

--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -149,7 +149,8 @@ fn main() {
 
         for datum in analysis {
             for piece in datum.data {
-                let t1 = table.entry(piece.sym.to_owned()).or_insert(BTreeMap::new());
+                let sym = strings.add(piece.sym.to_owned());
+                let t1 = table.entry(Rc::clone(&sym)).or_insert(BTreeMap::new());
                 let t2 = t1.entry(piece.kind).or_insert(BTreeMap::new());
                 let p: &str = &path;
                 let t3 = t2.entry(p).or_insert(Vec::new());
@@ -167,12 +168,12 @@ fn main() {
                     contextsym: strings.add(piece.contextsym),
                 });
 
-                pretty_table.insert(piece.sym.to_owned(), piece.pretty.to_owned());
+                pretty_table.insert(Rc::clone(&sym), piece.pretty.to_owned());
 
                 let ch = piece.sym.chars().nth(0).unwrap();
                 if !(ch >= '0' && ch <= '9') && !piece.sym.contains(' ') {
                     let t1 = id_table.entry(piece.pretty.to_owned()).or_insert(BTreeSet::new());
-                    t1.insert(piece.sym.to_owned());
+                    t1.insert(sym);
                 }
             }
         }

--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -168,11 +168,12 @@ fn main() {
                     contextsym: strings.add(piece.contextsym),
                 });
 
-                pretty_table.insert(Rc::clone(&sym), piece.pretty.to_owned());
+                let pretty = strings.add(piece.pretty.to_owned());
+                pretty_table.insert(Rc::clone(&sym), Rc::clone(&pretty));
 
                 let ch = piece.sym.chars().nth(0).unwrap();
                 if !(ch >= '0' && ch <= '9') && !piece.sym.contains(' ') {
-                    let t1 = id_table.entry(piece.pretty.to_owned()).or_insert(BTreeSet::new());
+                    let t1 = id_table.entry(pretty).or_insert(BTreeSet::new());
                     t1.insert(sym);
                 }
             }


### PR DESCRIPTION
(This includes my patch for bug 1416876 because it is based on top of that and I don't know how to do that the right way.)

I did some light local testing, all the way up to running a webserver for the results of a full Firefox run and the few things I checked seemed ok. The output from this file was also unchanged, when I checked it for the small set of test files.