### PR TITLE
Make the blame repo optional.

### DIFF
--- a/tests/config.json
+++ b/tests/config.json
@@ -13,6 +13,7 @@
       "index_path": "$WORKING/searchfox",
       "files_path": "$WORKING/searchfox/files",
       "objdir_path": "$WORKING/searchfox/objdir",
+      "git_path": "$MOZSEARCH_PATH",
       "codesearch_path": "$WORKING/searchfox/livegrep.idx",
       "codesearch_port": 8081
     }

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -50,13 +50,16 @@ fn main() {
     let (blame_commit, head_oid) = match &tree_config.git {
         &Some(ref git) => {
             let head_oid = git.repo.refname_to_id("HEAD").unwrap();
-            let blame_oid = git.blame_repo.refname_to_id("HEAD").unwrap();
-            let blame_commit = Some(git.blame_repo.find_commit(blame_oid).unwrap());
+            let blame_commit = if let Some(ref blame_repo) = git.blame_repo {
+                let blame_oid = blame_repo.refname_to_id("HEAD").unwrap();
+                Some(blame_repo.find_commit(blame_oid).unwrap())
+            } else {
+                None
+            };
             (blame_commit, Some(head_oid))
         },
         &None => (None, None),
     };
-    let blame_commit_ref = match blame_commit { Some(ref bc) => Some(bc), None => None };
 
     for path in fname_args {
         println!("File {}", path);
@@ -154,7 +157,7 @@ fn main() {
                          tree_name,
                          &panel,
                          None,
-                         blame_commit_ref,
+                         &blame_commit,
                          path,
                          input,
                          &jumps,

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -20,7 +20,7 @@ pub struct TreeConfigPaths {
 
 pub struct GitData {
     pub repo: Repository,
-    pub blame_repo: Repository,
+    pub blame_repo: Option<Repository>,
 
     pub blame_map: HashMap<Oid, Oid>, // Maps repo OID to blame_repo OID.
     pub hg_map: HashMap<Oid, String>, // Maps repo OID to Hg rev.
@@ -107,9 +107,17 @@ pub fn load(config_path: &str, need_indexes: bool) -> Config {
 
                 Some(GitData {
                     repo: repo,
-                    blame_repo: blame_repo,
+                    blame_repo: Some(blame_repo),
                     blame_map: blame_map,
                     hg_map: hg_map,
+                })
+            },
+            (&Some(ref git_path), &None) => {
+                Some(GitData {
+                    repo: Repository::open(&git_path).unwrap(),
+                    blame_repo: None,
+                    blame_map: HashMap::new(),
+                    hg_map: HashMap::new(),
                 })
             },
             _ => None,


### PR DESCRIPTION
This makes it so that we can specify a git repo in the config.json
without a blame repo, and get the partial functionality that unlocks.
In particular this enables the navigation panel if the tree has a git
repo specified, even if it doesn't have the blame repo.
This also adds the searchfox git repo to the tests/config.json file, so
now using the test repos it's possible to exercise the navigation panel.

Note that the links in the navigation panel are still hard-coded to
mozilla-central/gecko-dev which is a separate pre-existing issue (happens
on e.g. the nss repo on searchfox.org as well).