### PR TITLE
Allow the config.json to specify the hg root

### DIFF
--- a/tests/config.json
+++ b/tests/config.json
@@ -15,7 +15,8 @@
       "objdir_path": "$WORKING/searchfox/objdir",
       "git_path": "$MOZSEARCH_PATH",
       "codesearch_path": "$WORKING/searchfox/livegrep.idx",
-      "codesearch_port": 8081
+      "codesearch_port": 8081,
+      "hg_root": "https://hg.mozilla.org/nonexistent-searchfox-hg-mirror"
     }
   }
 }

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -141,11 +141,11 @@ fn main() {
                     update_link_lineno: true,
                 }, PanelItem {
                     title: "Log".to_owned(),
-                    link: format!("https://hg.mozilla.org/mozilla-central/log/tip/{}", path),
+                    link: format!("{}/log/tip/{}", config::get_hg_root(tree_config), path),
                     update_link_lineno: false,
                  }, PanelItem {
                     title: "Raw".to_owned(),
-                    link: format!("https://hg.mozilla.org/mozilla-central/raw-file/{}/{}", hg_rev, path),
+                    link: format!("{}/raw-file/{}/{}", config::get_hg_root(tree_config), hg_rev, path),
                     update_link_lineno: false,
                 }, PanelItem {
                     title: "Blame".to_owned(),

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -129,6 +129,10 @@ fn main() {
         let panel = if path.contains("__GENERATED__") {
             vec![]
         } else if let Some(oid) = head_oid {
+            let hg_rev : &str = tree_config.git.as_ref()
+                .and_then(|git| git.hg_map.get(&oid))
+                .and_then(|rev| Some(rev.as_ref())) // &String to &str conversion
+                .unwrap_or(&"tip");
             vec![PanelSection {
                 name: "Revision control".to_owned(),
                 items: vec![PanelItem {
@@ -141,7 +145,7 @@ fn main() {
                     update_link_lineno: false,
                  }, PanelItem {
                     title: "Raw".to_owned(),
-                    link: format!("https://raw.githubusercontent.com/mozilla/gecko-dev/{}/{}", oid, path),
+                    link: format!("https://hg.mozilla.org/mozilla-central/raw-file/{}/{}", hg_rev, path),
                     update_link_lineno: false,
                 }, PanelItem {
                     title: "Blame".to_owned(),

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -16,6 +16,7 @@ pub struct TreeConfigPaths {
     pub git_path: Option<String>,
     pub git_blame_path: Option<String>,
     pub objdir_path: String,
+    pub hg_root: Option<String>,
 }
 
 pub struct GitData {
@@ -47,6 +48,17 @@ pub fn get_git_path(tree_config: &TreeConfig) -> Result<&str, &'static str> {
     match &tree_config.paths.git_path {
         &Some(ref git_path) => Ok(git_path),
         &None => Err("History data unavailable"),
+    }
+}
+
+pub fn get_hg_root(tree_config: &TreeConfig) -> String {
+    // For temporary backwards compatibility, produce the m-c root if
+    // there isn't one specified. We can remove this once all relevant
+    // deployed config.json files have an explicit hg root, and make
+    // this return an Option<&str> instead.
+    match &tree_config.paths.hg_root {
+        &Some(ref hg_root) => hg_root.clone(),
+        &None => String::from("https://hg.mozilla.org/mozilla-central"),
     }
 }
 

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -425,7 +425,7 @@ pub fn format_path(cfg: &config::Config,
             update_link_lineno: true,
         }, PanelItem {
             title: "Log".to_owned(),
-            link: format!("https://hg.mozilla.org/mozilla-central/log/tip/{}", path),
+            link: format!("{}/log/tip/{}", config::get_hg_root(tree_config), path),
             update_link_lineno: false,
         }, PanelItem {
             title: "Blame".to_owned(),
@@ -601,7 +601,7 @@ pub fn format_diff(cfg: &config::Config,
             update_link_lineno: true,
         }, PanelItem {
             title: "Log".to_owned(),
-            link: format!("https://hg.mozilla.org/mozilla-central/log/tip/{}", path),
+            link: format!("{}/log/tip/{}", config::get_hg_root(tree_config), path),
             update_link_lineno: false,
         }],
     }];
@@ -744,7 +744,7 @@ fn generate_commit_info(tree_name: &str,
     let git = try!(config::get_git(tree_config));
     let hg = match git.hg_map.get(&commit.id()) {
         Some(hg_id) => {
-            let hg_link = format!("<a href=\"https://hg.mozilla.org/mozilla-central/rev/{}\">{}</a>", hg_id, hg_id);
+            let hg_link = format!("<a href=\"{}/rev/{}\">{}</a>", config::get_hg_root(tree_config), hg_id, hg_id);
             vec![F::T(format!("<tr><td>hg</td><td>{}</td></tr>", hg_link))]
         },
 


### PR DESCRIPTION
This allows a repo to override the hg URL root so that the log/raw links point to the right repos. Combined with a patch to the mozsearch-mozilla repo (will make a PR on that as well) this should fix https://bugzilla.mozilla.org/show_bug.cgi?id=1325043