### PR TITLE
Bug 1282151 - Show changeset bar even for tip revision

### DIFF
--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -153,10 +153,13 @@ fn main() {
             vec![]
         };
 
+        let head_commit = head_oid
+            .and_then(|oid| tree_config.git.as_ref().unwrap().repo.find_commit(oid).ok());
+
         format_file_data(&cfg,
                          tree_name,
                          &panel,
-                         &None,
+                         &head_commit,
                          &blame_commit,
                          path,
                          input,


### PR DESCRIPTION
Pass in the head commit to format_file_data so it shows the changeset bar, to fix bug 1282151.