### PR TITLE
Use https URLs for fetching the xpidl analyzer code, to avoid a 301 r…

### DIFF
--- a/scripts/idl-analyze.sh
+++ b/scripts/idl-analyze.sh
@@ -24,12 +24,12 @@ fi
 rm -rf /tmp/pymodules
 mkdir /tmp/pymodules
 pushd /tmp/pymodules
-wget "http://hg.mozilla.org/mozilla-central/raw-file/tip/xpcom/idl-parser/xpidl/xpidl.py"
+wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/xpcom/idl-parser/xpidl/xpidl.py"
 mkdir ply
 pushd ply
-wget "http://hg.mozilla.org/mozilla-central/raw-file/tip/other-licenses/ply/ply/__init__.py"
-wget "http://hg.mozilla.org/mozilla-central/raw-file/tip/other-licenses/ply/ply/lex.py"
-wget "http://hg.mozilla.org/mozilla-central/raw-file/tip/other-licenses/ply/ply/yacc.py"
+wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/other-licenses/ply/ply/__init__.py"
+wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/other-licenses/ply/ply/lex.py"
+wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/other-licenses/ply/ply/yacc.py"
 popd
 popd
 


### PR DESCRIPTION
…edirect