### PR TITLE
Zero-pad the line numbers in the analysis file.

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -196,9 +196,9 @@ private:
     }
 
     if (Length) {
-      return stringFormat("%d:%d-%d", Line, Column - 1, Column - 1 + Length);
+      return stringFormat("%05d:%d-%d", Line, Column - 1, Column - 1 + Length);
     } else {
-      return stringFormat("%d:%d", Line, Column - 1);
+      return stringFormat("%05d:%d", Line, Column - 1);
     }
   }
 


### PR DESCRIPTION
This makes it easier to look at the analysis file and compare it to the
raw source file because the line numbers are better sequenced.

(Feel free to reject this change - I just found it slightly useful in the particular thing I was looking at, but I don't know if it's going to be widely useful and is worth the extra bytes cost)