### PR TITLE
Don't ignore /static/js subtree.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ fastcgi/obj
 *.so
 *.pyc
 clang-plugin/testfiles
-js
+/js
 tools/target
 paths
 config.json


### PR DESCRIPTION
Some editors (like atom) may be configured to hide directories that are
.gitignore'd.  When there's no slash, the ignore matches /static/js.