### PR TITLE
Add analyze target to clang-plugin, to quickly run the analyzer on th…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ fastcgi/obj
 *.so
 *.pyc
 clang-plugin/testfiles
+clang-plugin/analysis
 js
 tools/target
 paths

--- a/clang-plugin/Makefile
+++ b/clang-plugin/Makefile
@@ -19,4 +19,22 @@ check: build
 clean:
 	$(RM) *.o *.dwo libclang-index-plugin.so
 
+dump: build
+	-clang++ -c -Xclang -ast-dump testfiles/test.cpp
+
+analyze: build
+	@if [ ! -d objdir ]; then mkdir objdir; fi
+	@if [ ! -d analysis ]; then mkdir analysis; fi
+	-$(RM) analysis/*
+	-clang++ -c \
+		-Xclang -load                       -Xclang ./libclang-index-plugin.so \
+		-Xclang -add-plugin                 -Xclang mozsearch-index \
+		-Xclang -plugin-arg-mozsearch-index -Xclang testfiles/ \
+		-Xclang -plugin-arg-mozsearch-index -Xclang analysis/ \
+		-Xclang -plugin-arg-mozsearch-index -Xclang objdir/ \
+		testfiles/test.cpp
+	@echo "-------------------------------------------"
+	@echo "Analysis output is in the analysis/ folder"
+	@echo "-------------------------------------------"
+
 .PHONY: build clean


### PR DESCRIPTION
…e test file

This just makes a little easier to quickly iterate when hacking on the indexer. Note that nothing ever goes into the created objdir folder to it's not necessary to add it to the gitignore list.